### PR TITLE
fix: comments now correctly support markdown.

### DIFF
--- a/src/components/ui/MovieComment.jsx
+++ b/src/components/ui/MovieComment.jsx
@@ -31,9 +31,13 @@ const MovieComment = ({ review }) => {
         <MovieRating rating={review?.rating} ratingScale={5} showVoteCount={false} />
       </CardHeader>
       <CardContent>
-        <MarkdownPreview>
-          {review?.comment || 'No comment available.'}
-        </MarkdownPreview>
+        {review?.user_profiles?.role === 'contributor' ? (
+          <MarkdownPreview>
+            {review?.comment || 'No comment available.'}
+          </MarkdownPreview>
+        ) : (
+          <p>{review?.comment || 'No comment available.'}</p>
+        )}
       </CardContent>
       <CardFooter className="w-fit flex gap-2 ml-auto text-muted-foreground">
         <CalendarDaysIcon className="max-w-6" />

--- a/src/components/users/UserProfileReview.jsx
+++ b/src/components/users/UserProfileReview.jsx
@@ -5,6 +5,7 @@ import { truncateText } from '@/utils/string/truncate';
 import RoleBadge from '../ui/RoleBadge';
 import { CalendarDaysIcon, Clapperboard } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import MarkdownPreview from '../MarkdownPreview';
 
 const UserProfileReview = ({ review }) => {
   if (!review) return <Skeleton className="w-full h-40" />;
@@ -54,7 +55,11 @@ const UserProfileReview = ({ review }) => {
           </Link>
         </div>
         <div className="flex flex-col gap-2 flex-1">
-          <p>{truncateText(comment, 600, '...')}</p>
+          {role === 'contributor' ? (
+            <MarkdownPreview>{truncateText(comment, 600, '...')}</MarkdownPreview>
+          ) : (
+            <p>{truncateText(comment, 600, '...')}</p>
+          )}
         </div>
       </CardContent>
       <CardFooter className="w-full flex justify-between flex-wrap gap-4 items-center text-muted-foreground">

--- a/src/index.css
+++ b/src/index.css
@@ -61,7 +61,7 @@
 }
 
 .mdxeditor-toolbar {
-  @apply bg-background fixed bottom-0 left-0 w-full h-fit mt-auto overflow-x-scroll md:overflow-hidden md:static;
+  @apply bg-background fixed bottom-0 left-0 w-full h-fit mt-auto overflow-x-scroll md:overflow-hidden md:sticky md:left-0 md:top-0;
 }
 
 .mdxeditor-toolbar [data-toolbar-item='true'][data-state='on'],

--- a/src/pages/CreateWikiPage.jsx
+++ b/src/pages/CreateWikiPage.jsx
@@ -28,12 +28,16 @@ const FormSchema = z.object({
 
 const CreateWikiPage = () => {
   const { movieId } = useParams();
+
   const { session } = useAuth();
+
   const { getWikiMovie, updateWikiMovie, insertWikiMovie } = useWikiMovie(movieId);
   const { data: wikiData, isLoading: isWikiDataLoading } = getWikiMovie;
+
   const { useMovieDetails } = useMovies();
   const { data: movieData, isLoading: isMovieDataLoading } =
     useMovieDetails(movieId);
+
   const navigate = useNavigate();
   const { toast } = useToast();
 


### PR DESCRIPTION
- Reviews from users with the role 'user' are not displayed in markdown.
- Reviews by users with the 'contributor' role are displayed in markdown.
- The markdown editor toolbar is now sticky top to improve the wiki page editing experience.